### PR TITLE
Reduce unnecessary perms.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "author": "BassGaming",
   "description": "TTS implementation for the OpenAI api format. Click 'Read Selected Text' in the context menu after highlighting text.",
   "version": "1.4.1",
-  "permissions": ["storage", "contextMenus", "activeTab", "tabs", "webRequest", "webRequestBlocking", "downloads", "<all_urls>"],
+  "permissions": ["storage", "contextMenus"],
   "content_security_policy": "default-src 'self' https:; connect-src https:;",
   "background": {
     "scripts": ["background.js"],


### PR DESCRIPTION
Firstly, thank you so much for making this. i always wanted to use a read-aloud extension while still being able to use my own local models.

one thing that stopped me from wanting to continue using it was the excessive permissions which i thought was unnecessary. i was so glad you shared the code so users can do their own due diligence and check the code to see there isn't anything malicious under the hood, should they be wary like me. but i think it would be better to remove the excessive perms for security reasons as well as to give other users a peace of mind.

i went on to test it myself and slowly removed permissions until only the ones necessary for it to function were left. context was needed for the right click option to show up, storage was necessary for the variables.

**Important Note**
I only done tests using a locally run OpenAI formatted API(f5tts) ran on a python env. Some things i have not tested are docker container setups and streaming mode. I hope others who have access to a TTS with this 2 setups can test it as well to make sure it doesnt break anything.