### PR TITLE
add shortcut keys

### DIFF
--- a/background.js
+++ b/background.js
@@ -704,3 +704,37 @@ async function processPCMStream(response) {
     }
   }
 }
+
+browser.commands.onCommand.addListener((command) => {
+  if (command === "read-selected-text") {
+    browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+      browser.tabs.executeScript(tabs[0].id, {
+        code: "window.getSelection().toString();",
+      }).then((results) => {
+        const selectedText = results[0];
+        if (selectedText) {
+          processText(selectedText);
+        }
+      });
+    });
+  } else if (command === "stop-playback") {
+    stopRequested = true;
+    pcmStreamStopped = true;
+    audioQueue.forEach(url => URL.revokeObjectURL(url));
+    audioQueue = [];
+    isPlaying = false;
+    setPlaybackState("idle");
+    if (currentAbortController) {
+      currentAbortController.abort();
+      currentAbortController = null;
+    }
+    if (audioContext) {
+      audioContext.close();
+      audioContext = null;
+    }
+    if (currentAudio) {
+      currentAudio.pause();
+      currentAudio = null;
+    }
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "author": "BassGaming",
   "description": "TTS implementation for the OpenAI api format. Click 'Read Selected Text' in the context menu after highlighting text.",
   "version": "1.5.2",
-  "permissions": ["storage", "contextMenus", "activeTab", "tabs", "downloads","<all_urls>"],
+  "permissions": ["storage", "contextMenus", "activeTab", "tabs", "downloads", "<all_urls>"],
   "content_security_policy": "default-src 'self'; style-src 'unsafe-inline'; connect-src 'self' http://localhost:* http://127.0.0.1:* http://host.docker.internal:* https: http:; media-src 'self' blob:;",
   "background": {
     "scripts": ["shared/config.js", "shared/notifications.js", "background.js"],
@@ -12,7 +12,21 @@
   },
   "options_ui": {
     "page": "options.html",
-    "chrome_style": true
+    "open_in_tab": true
+  },
+  "commands": {
+    "read-selected-text": {
+      "suggested_key": {
+        "default": "Alt+Shift+R"
+      },
+      "description": "Read selected text"
+    },
+    "stop-playback": {
+      "suggested_key": {
+        "default": "Alt+Shift+S"
+      },
+      "description": "Stop playback"
+    }
   },
   "icons": {
     "48": "icons/icon.png"
@@ -22,14 +36,12 @@
     "default_icon": "icons/icon.png",
     "default_title": "Custom TTS Reader"
   },
-"browser_specific_settings": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "{cfc0ee5e-1bc1-4e83-95b9-98b530ba7403}",
       "strict_min_version": "79.0",
       "data_collection_permissions": {
-        "required": [
-          "none"
-        ],
+        "required": ["none"],
         "optional": []
       }
     },


### PR DESCRIPTION
This pr attempts to add shortcut keys to this extension for more seamless inference with TTS models. Previously users had to right click and then select extension from context menu.

LLMs were used to assist in this implementation